### PR TITLE
Fix for Humble installation by replacing deprecated CMake macro "rosidl_target_interfaces"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,7 @@ add_executable(${PROJECT_NAME}_node
   external/kdtree/kdtree.c
 )
 add_dependencies(${PROJECT_NAME}_node ${PROJECT_NAME})
-rosidl_target_interfaces(${PROJECT_NAME}_node
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
-target_link_libraries(${PROJECT_NAME}_node gtsam)
+target_link_libraries(${PROJECT_NAME}_node gtsam "${PROJECT_NAME}__rosidl_typesupport_cpp")
 ament_target_dependencies(${PROJECT_NAME}_node
   rclcpp
   sensor_msgs
@@ -85,8 +83,7 @@ ament_target_dependencies(${PROJECT_NAME}_node
 # add mission node
 add_executable(mission_node src/mission_node.cpp src/common.cpp)
 add_dependencies(mission_node ${PROJECT_NAME})
-rosidl_target_interfaces(mission_node
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(mission_node "${PROJECT_NAME}__rosidl_typesupport_cpp")
 ament_target_dependencies(mission_node
   rclcpp
   sensor_msgs
@@ -98,8 +95,7 @@ ament_target_dependencies(mission_node
 add_executable(visualization_node 
   src/visualization/rviz_visualizer.cpp src/common.cpp)
 add_dependencies(visualization_node ${PROJECT_NAME})
-rosidl_target_interfaces(visualization_node
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(visualization_node "${PROJECT_NAME}__rosidl_typesupport_cpp")
 ament_target_dependencies(visualization_node
   rclcpp
   sensor_msgs
@@ -114,8 +110,7 @@ ament_target_dependencies(visualization_node
 add_executable(april_detection_proxy_node 
   src/april_detection_proxy.cpp src/common.cpp)
 add_dependencies(april_detection_proxy_node ${PROJECT_NAME})
-rosidl_target_interfaces(april_detection_proxy_node
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(april_detection_proxy_node "${PROJECT_NAME}__rosidl_typesupport_cpp")
 ament_target_dependencies(april_detection_proxy_node
   rclcpp
   sensor_msgs


### PR DESCRIPTION
This fix aims to solve issue #4 for installation on Humble, not exactly sure why it happens but I believe this is due to the deprecated CMake macro for  `rosidl_target_interfaces`. Would like help to test this for galactic to ensure not breaking changes were introduced.